### PR TITLE
fix typo.

### DIFF
--- a/books/go/0440-memory-pooling/010-sync-pool.md
+++ b/books/go/0440-memory-pooling/010-sync-pool.md
@@ -38,7 +38,7 @@ func main() {
     // Get 'another' buffer
     s = pool.Get().(*bytes.Buffer)
     // Write to it
-    s.Write([]bytes("append"))
+    s.Write([]byte("append"))
     // At this point, if GC ran, this buffer *might* exist already, in
     // which case it will contain the bytes of the string "dirtyappend"
     fmt.Println(s)


### PR DESCRIPTION
Hi.

This PR is typo fix.
Following memory pooling, sync pool 's code,

https://play.golang.org/p/xDLEmNYlfjn
```bash
prog.go:33:13: use of package bytes without selector
```

Actually, line 33, "bytes" -> "byte"??

https://play.golang.org/p/HxS6y7z2ZKb
```bash
dirtyappend
reset!
```

If this is bug, Please merge this.

Best Regards,
nnao45