### PR TITLE
Update 010-creating-slices.md

### DIFF
--- a/books/go/0080-slices/010-creating-slices.md
+++ b/books/go/0080-slices/010-creating-slices.md
@@ -36,6 +36,6 @@ You can access elements in a slice using typical indexing syntax.
 You can also use a `for` loop over slices with `range`. The first variable is the index in the specified array, and the second variable is the value for the index.
 
     for index, value := range a {
-        fmt.Println("Index: " + index + " Value: " + value)  // Prints "Index: 0 Value: 5" (and continues until end of slice)
+        fmt.Printf("Index: %v Value: %v\n", index, value)  // Prints "Index: 0 Value: 5" (and continues until end of slice)
     }
 


### PR DESCRIPTION
Whoever wrote this has confused JavaScript syntax with Go.
```go
for index, value := range a {
    fmt.Println("Index: " + index + " Value: " + value)  // Prints "Index: 0 Value: 5" (and continues until end of slice)
}
```
I have replaced it with `fmt.Printf("Index: %v Value: %v\n, index, value)` and now should work as expected.